### PR TITLE
Iframe widget

### DIFF
--- a/app/widgets/frame/frame.settings.tpl.html
+++ b/app/widgets/frame/frame.settings.tpl.html
@@ -9,11 +9,8 @@
             <tabset>
                 <tab heading="General">
                     <br />
-
                     <div class="row">
                         <div class="col-md-12">
-
-
                             <div class="form-group" ng-class="{error: _form.name.$error && _form.submitted}">
                                 <label class="control-label col-lg-3 col-md-3">Name</label>
                                 <div class="col-lg-9 col-md-9">
@@ -26,13 +23,9 @@
                                     <input type="url" name="frameUrl" ng-model="form.frameUrl" class="form-control">
                                 </div>
                             </div>
-
-
                         </div>
                     </div>
-
                 </tab>
-
                 <tab heading="Advanced">
                     <br />
                     <div class="row">
@@ -65,14 +58,14 @@
                             </div>
                         </div>
                     </div>
-                </div>
-            </tab>
+                </tab>
+            </tabset>
+        </div>
 
-
-            <div class="modal-footer">
-                <a ng-click="remove()" class="btn btn-danger pull-left" tabindex="-1"><i class="glyphicon glyphicon-trash"></i>&nbsp;Delete</a>
-                <a ng-click="dismiss()" class="btn btn-default" tabindex="-1"><i class="glyphicon glyphicon-remove"></i>&nbsp;Cancel</a>
-                <button type="submit" class="btn btn-primary"><i class="glyphicon glyphicon-ok"></i>&nbsp;Save</button>
-            </div>
-        </form>
-    </div>
+        <div class="modal-footer">
+            <a ng-click="remove()" class="btn btn-danger pull-left" tabindex="-1"><i class="glyphicon glyphicon-trash"></i>&nbsp;Delete</a>
+            <a ng-click="dismiss()" class="btn btn-default" tabindex="-1"><i class="glyphicon glyphicon-remove"></i>&nbsp;Cancel</a>
+            <button type="submit" class="btn btn-primary"><i class="glyphicon glyphicon-ok"></i>&nbsp;Save</button>
+        </div>
+    </form>
+</div>

--- a/app/widgets/frame/frame.settings.tpl.html
+++ b/app/widgets/frame/frame.settings.tpl.html
@@ -1,0 +1,78 @@
+<div>
+    <form name="_form" class="form-horizontal" ng-submit="submit(_form)">
+        <div class="modal-header">
+            <button type="button" class="close" ng-click="dismiss()" aria-hidden="true">&times;</button>
+            <h3>iFrame Settings</h3>
+        </div>
+
+        <div class="modal-body">
+            <tabset>
+                <tab heading="General">
+                    <br />
+
+                    <div class="row">
+                        <div class="col-md-12">
+
+
+                            <div class="form-group" ng-class="{error: _form.name.$error && _form.submitted}">
+                                <label class="control-label col-lg-3 col-md-3">Name</label>
+                                <div class="col-lg-9 col-md-9">
+                                    <input name="name" type="text" ng-model="form.name" class="form-control" />
+                                </div>
+                            </div>
+                            <div class="form-group" ng-class="{error: _form.frameUrl.$error && _form.submitted}">
+                                <label class="control-label col-lg-3 col-md-3">Url</label>
+                                <div class="col-lg-9 col-md-9">
+                                    <input type="url" name="frameUrl" ng-model="form.frameUrl" class="form-control">
+                                </div>
+                            </div>
+
+
+                        </div>
+                    </div>
+
+                </tab>
+
+                <tab heading="Advanced">
+                    <br />
+                    <div class="row">
+                        <div class="col-md-12">
+                            <div class="form-group" ng-class="{error: _form.background.$error && _form.submitted}">
+                                <label class="control-label col-lg-3 col-md-3">iFrame background color</label>
+                                <div class="col-lg-9 col-md-9">
+                                    <div dab-model="form.background" web-colorpicker dab-width="20" dab-height="20" dab-radius="50" dab-vertical="4" dab-rotate="0" show-grayscale="true"></div>
+                                </div>
+                            </div>
+                            <div class="form-group" ng-class="{error: _form.frameless.$error && _form.submitted}">
+                                <label class="control-label col-lg-3 col-md-3">Frameless</label>
+                                <div class="col-lg-9 col-md-9">
+                                    <div class="checkbox">
+                                        <label>
+                                            <input type="checkbox" name="frameless" ng-model="form.frameless" /> Fill to edges
+                                        </label>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="form-group" ng-class="{error: _form.hidelabels.$error && _form.submitted}">
+                                <label class="control-label col-lg-3 col-md-3">Label</label>
+                                <div class="col-lg-9 col-md-9">
+                                    <div class="checkbox">
+                                        <label>
+                                            <input type="checkbox" name="hidelabel" ng-model="form.hidelabel" /> Hide title label
+                                        </label>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </tab>
+
+
+            <div class="modal-footer">
+                <a ng-click="remove()" class="btn btn-danger pull-left" tabindex="-1"><i class="glyphicon glyphicon-trash"></i>&nbsp;Delete</a>
+                <a ng-click="dismiss()" class="btn btn-default" tabindex="-1"><i class="glyphicon glyphicon-remove"></i>&nbsp;Cancel</a>
+                <button type="submit" class="btn btn-primary"><i class="glyphicon glyphicon-ok"></i>&nbsp;Save</button>
+            </div>
+        </form>
+    </div>

--- a/app/widgets/frame/frame.tpl.html
+++ b/app/widgets/frame/frame.tpl.html
@@ -1,0 +1,8 @@
+<div  class="box-content frame" >
+	<div ng-class="{ 'frame-content': !vm.widget.frameless, 'frame-content-frameless': vm.widget.frameless }">		
+		<div class="frame-label" ng-hide="vm.widget.hidelabel">{{vm.widget.name}}</div>
+		<div class="frame-container">
+			<iframe width="100%" height="100%" name="{{vm.ngModel.name}}" ng-src="{{detailFrame}}"  ng-style="{ 'background-color': vm.widget.background }" frameborder="0"> </iframe>
+		</div>
+	</div>
+</div>

--- a/app/widgets/frame/frame.widget.js
+++ b/app/widgets/frame/frame.widget.js
@@ -1,0 +1,85 @@
+(function() {
+    'use strict';
+
+    angular
+        .module('app.widgets')
+        .directive('widgetFrame', widgetFrame)
+        .controller('WidgetSettingsCtrl-frame', WidgetSettingsCtrlFrame)
+        .config(function (WidgetsProvider) { 
+            WidgetsProvider.$get().registerType({
+                type: 'frame',
+                displayName: 'Frame',
+                description: 'A fixed label used for headers etc. (no OpenHAB item binding)'
+            });
+        });
+
+    widgetFrame.$inject = ['$rootScope', '$modal', 'OHService', '$sce'];
+    function widgetFrame($rootScope, $modal, OHService, $sce) {
+        // Usage: <widget-label ng-model="widget" />
+        //
+        // Creates: A label widget
+        //
+        var directive = {
+            bindToController: true,
+            controller: FrameController,
+            controllerAs: 'vm',
+            link: link,
+            restrict: 'AE',
+            templateUrl: 'app/widgets/frame/frame.tpl.html',
+            scope: {
+                ngModel: '='
+            }
+        };
+
+        return directive;
+        
+        function link(scope, element, attrs) {
+        }
+    }
+    FrameController.$inject = ['$rootScope', '$scope', 'OHService', '$sce'];
+    function FrameController ($rootScope, $scope, OHService, $sce) {
+        var vm = this;
+        this.widget = this.ngModel;
+        $scope.detailFrame = $sce.trustAsResourceUrl(this.widget.frameUrl);
+       
+    };
+
+
+    // settings dialog
+    WidgetSettingsCtrlFrame.$inject = ['$scope', '$timeout', '$rootScope', '$modalInstance', 'widget', 'OHService', '$sce'];
+
+    function WidgetSettingsCtrlFrame($scope, $timeout, $rootScope, $modalInstance, widget, OHService, $sce) {
+        $scope.widget = widget;
+        $scope.items = OHService.getItems();
+
+        $scope.form = {
+            name: widget.name,
+            sizeX: widget.sizeX,
+            sizeY: widget.sizeY,
+            col: widget.col,
+            row: widget.row,
+            frameUrl: widget.frameUrl,
+            frameless: widget.frameless,
+            hidelabel: widget.hidelabel,
+            background: widget.background
+        };    
+
+        $scope.dismiss = function() {
+            $modalInstance.dismiss();
+        };
+
+        $scope.remove = function() {
+            $scope.dashboard.widgets.splice($scope.dashboard.widgets.indexOf(widget), 1);
+            $modalInstance.close();
+        };
+
+        $scope.submit = function() {
+            angular.extend(widget, $scope.form);
+
+            $modalInstance.close(widget);
+        };
+
+    }
+
+
+})();

--- a/assets/style.css
+++ b/assets/style.css
@@ -242,3 +242,13 @@ form {
     bottom: 0;
     left: 0;
 }
+
+
+/* colour picker */
+.color-picker-swatch {
+    border: #3960FF 1px dotted;
+}
+.transparent-swatch-arrow {
+    padding-left: 3px;
+    padding-top: 8px;
+}

--- a/assets/style.css
+++ b/assets/style.css
@@ -119,6 +119,7 @@ form {
 
 /* Widget styles */
 
+
 .labelwidget {
     display: flex;
 }
@@ -218,4 +219,26 @@ form {
     zoom: 15;
     width: 100%;
     height: 100%;
+}
+
+/* iframe */
+
+.frame-content, .frame-content-frameless, .frame-container {
+    position: relative;
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+
+}
+
+.frame .frame-label {
+    padding-bottom: 10px;
+}
+
+.frame-content-frameless {
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
 }

--- a/index.html
+++ b/index.html
@@ -45,6 +45,7 @@
 	<script src="app/widgets/switch/switch.widget.js"></script>
 	<script src="app/widgets/slider/slider.widget.js"></script>
 	<script src="app/widgets/label/label.widget.js"></script>
+	<script src="app/widgets/frame/frame.widget.js"></script>
 	<script src="app/widgets/image/image.widget.js"></script>
 	<script src="app/widgets/button/button.widget.js"></script>
 

--- a/vendor/angular-web-colorpicker.js
+++ b/vendor/angular-web-colorpicker.js
@@ -4,10 +4,11 @@ angular.module('web.colorpicker').directive('webColorpicker', function() {
   return {
     template: '<div>' +
       '<div ng-repeat="row in rows" ng-style="{ \'margin-left\': \'\' + row.offset*dabWidth +\'px\', height: \'\' + dabHeight - dabVertical + \'px\', \'min-width\': \'\' + 13*dabWidth + \'px\' }">' +
-      '<div ng-repeat="color in row.colors" ng-click="selectColor(color)" style="display: inline-block; position: relative; cursor: pointer;" ng-style="{ \'box-shadow\': color == dabModel ? \'0 0 0 2px hsl(0, 0%, 100%),0 0 0 4px hsl(0, 0%, 15%)\' : \'none\', \'z-index\': color == dabModel ? 3 : 2, \'background-color\': color, height: \'\' + dabHeight + \'px\', width: \'\' + dabWidth + \'px\', \'border-radius\': \'\' + dabRadius + \'%\', transform: \'rotate(\' + dabRotate + \'deg)\', \'margin-top\': \'\' + dabTop + \'px\' }">' +
+      '<div class="color-picker-swatch" ng-repeat="color in row.colors" ng-click="selectColor(color)" style="display: inline-block; position: relative; cursor: pointer;" ng-style="{ \'box-shadow\': color == dabModel ? \'0 0 0 2px hsl(0, 0%, 100%),0 0 0 4px hsl(0, 0%, 15%)\' : \'none\', \'z-index\': color == dabModel ? 3 : 2, \'background-color\': color, height: \'\' + dabHeight + \'px\', width: \'\' + dabWidth + \'px\', \'border-radius\': \'\' + dabRadius + \'%\', transform: \'rotate(\' + dabRotate + \'deg)\', \'margin-top\': \'\' + dabTop + \'px\' }">' +
       '</div>' +
       '</div>' +
-      '</div>',
+      '</div>' +
+      '<div class="transparent-swatch-arrow"><i class="glyphicon glyphicon-arrow-up"></i> Transparent</div>',
     restrict: 'EA',
     scope: {
       dabModel: '=',
@@ -41,8 +42,10 @@ angular.module('web.colorpicker').directive('webColorpicker', function() {
       ];
 
       if (scope.showGrayscale) {
-      	scope.rows.push({ colors: [] })
-      	scope.rows.push({ offset: 1.5,  colors: ['#E6E6E6', '#CCCCCC', '#B3B3B3', '#999999', '#808080', '#666666', '#4C4C4C', '#333333', '#191919', '#000000'] })
+        scope.rows.push({ colors: [] })
+        scope.rows.push({ offset: 1.5,  colors: ['#E6E6E6', '#CCCCCC', '#B3B3B3', '#999999', '#808080', '#666666', '#4C4C4C', '#333333', '#191919', '#000000'] })
+        scope.rows.push({ colors: [] })
+        scope.rows.push({ offset: 0,  colors: ['transparent'] })
       }
 
       var area, i, len, ref;


### PR DESCRIPTION
A simple iFrame widget.

Results vary depending on the url you want to use e.g. www.bbc.co.uk doesn't work. The usual iFrame cross domain issues still apply, but it is fine when using your own simple pages.

My need was primarily to show the running logs in the dashboard using [js-logtail](https://github.com/ukhas/js-logtail)

I played with getting js-logtail within the webapps folder, but Jetty doesn't like symbolic links and you need to use with js-logtail. But very easy to add using something like lighttpd.

The frameless option allows a full bleed to the edges ignoring the 10px padding. If the HTML file doesn't have a background colour, you can manually set one using the same colour picker you use.

Also added a an option for "transparent" in the colour picker as once you set a colour there was no way to remove it.

